### PR TITLE
Use TimeLib.h, for compatibility with Arduino >=1.6.10 (newer avr-libc)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,7 +6,7 @@ Jack Christensen Mar 2012
 ![CC BY-SA](http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-sa.png)
 
 ##Introduction
-The **Timezone** library is designed to work in conjunction with the [Arduino Time library](http://www.arduino.cc/playground/Code/Time).  The Time library must be installed and referenced in your sketch with `#include <Time.h>`.  This documentation assumes some familiarity with the Time library.
+The **Timezone** library is designed to work in conjunction with the [Arduino Time library](http://www.arduino.cc/playground/Code/Time).  The Time library must be installed and referenced in your sketch with `#include <TimeLib.h>`.  This documentation assumes some familiarity with the Time library.
 
 The primary aim of the **Timezone** library is to convert Universal Coordinated Time (UTC) to the correct local time, whether it is daylight saving time (a.k.a. summer time) or standard time. The time source could be a GPS receiver, an NTP server, or a Real-Time Clock (RTC) set to UTC.  But whether a hardware RTC or other time source is even present is immaterial; although the Time library can function as a software RTC without additional hardware, its accuracy is dependent on the accuracy of the microcontroller's system clock.
 
@@ -77,7 +77,7 @@ By reading rules previously stored in EEPROM.  This reads both the daylight and 
 Note that **TimeChangeRule**s require 12 bytes of storage each, so the pair of rules associated with a Timezone object requires 24 bytes total.  This could possibly change in future versions of the library.  The size of a **TimeChangeRule** can be checked with `sizeof(usEDT)`.
 
 ##Timezone library methods
-Note that the `time_t` data type is defined by the Arduino Time library <Time.h>. See the [Time library documentation](http://www.arduino.cc/playground/Code/Time) for additional details.
+Note that the `time_t` data type is defined by the Arduino Time library <TimeLib.h>. See the [Time library documentation](http://www.arduino.cc/playground/Code/Time) for additional details.
 
 ###time_t toLocal(time_t utc);
 #####Description

--- a/Timezone.h
+++ b/Timezone.h
@@ -16,7 +16,7 @@
 #else
 #include <WProgram.h> 
 #endif
-#include <Time.h>              //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>              //http://www.arduino.cc/playground/Code/Time
 
 //convenient constants for dstRules
 enum week_t {Last, First, Second, Third, Fourth}; 

--- a/examples/Clock/Clock.pde
+++ b/examples/Clock/Clock.pde
@@ -11,7 +11,7 @@
  * San Francisco, California, 94105, USA.                               *
  *----------------------------------------------------------------------*/
 
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>     //http://www.arduino.cc/playground/Code/Time
 #include <Timezone.h>    //https://github.com/JChristensen/Timezone
 
 //US Eastern Time Zone (New York, Detroit)

--- a/examples/HardwareRTC/HardwareRTC.pde
+++ b/examples/HardwareRTC/HardwareRTC.pde
@@ -16,7 +16,7 @@
  *----------------------------------------------------------------------*/
 
 #include <DS1307RTC.h>   //http://www.arduino.cc/playground/Code/Time
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>     //http://www.arduino.cc/playground/Code/Time
 #include <Timezone.h>    //https://github.com/JChristensen/Timezone
 #include <Wire.h>        //http://arduino.cc/en/Reference/Wire (supplied with the Arduino IDE)
 

--- a/examples/WorldClock/WorldClock.pde
+++ b/examples/WorldClock/WorldClock.pde
@@ -14,7 +14,7 @@
  * San Francisco, California, 94105, USA.                               *
  *----------------------------------------------------------------------*/
 
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>     //http://www.arduino.cc/playground/Code/Time
 #include <Timezone.h>    //https://github.com/JChristensen/Timezone
 
 //Australia Eastern Time Zone (Sydney, Melbourne)

--- a/examples/WriteRules/WriteRules.pde
+++ b/examples/WriteRules/WriteRules.pde
@@ -10,7 +10,7 @@
  * San Francisco, California, 94105, USA.                               *
  *----------------------------------------------------------------------*/ 
 
-#include <Time.h>        //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>     //http://www.arduino.cc/playground/Code/Time
 #include <Timezone.h>    //https://github.com/JChristensen/Timezone
 
 //US Eastern Time Zone (New York, Detroit)


### PR DESCRIPTION
With this change the correct include file for the Time library will be
included in Arduino >= 1.6.10. The details and reasoning behind this
change can be found in the  Pull Request JChristensen/DS3232RTC#30.

This would also fix the issue JChristensen/Timezone#7.
