### PR TITLE
Add full support for ESP8266/ESP32

### DIFF
--- a/examples/WriteRules/WriteRules.ino
+++ b/examples/WriteRules/WriteRules.ino
@@ -6,6 +6,9 @@
 // Jack Christensen Mar 2012
 
 #include <Timezone.h>   // https://github.com/JChristensen/Timezone
+#if defined(ESP8266) || defined(ESP32)
+#include <EEPROM.h>     // bundled with your board's hardware package
+#endif  // defined(ESP8266) || defined(ESP32)
 
 // US Eastern Time Zone (New York, Detroit)
 TimeChangeRule usEdt = {"EDT", Second, Sun, Mar, 2, -240};    // UTC - 4 hours
@@ -15,6 +18,9 @@ Timezone usEastern(usEdt, usEst);
 void setup()
 {
     pinMode(13, OUTPUT);
+#if defined(ESP8266) || defined(ESP32)
+    EEPROM.begin(200);  // for ESP8266 and ESP32, configure the EEPROM size
+#endif  // defined(ESP8266) || defined(ESP32)
     usEastern.writeRules(100);    // write rules to EEPROM address 100
 }
 

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library to facilitate time zone conversions and automatic dayli
 paragraph=The primary aim of the Timezone library is to convert Universal Coordinated Time (UTC) to the correct local time, whether it is daylight saving time (a.k.a. summer time) or standard time.
 category=Timing
 url=https://github.com/JChristensen/Timezone
-architectures=avr
+architectures=avr,esp8266,esp32

--- a/src/Timezone.cpp
+++ b/src/Timezone.cpp
@@ -8,9 +8,9 @@
 
 #include "Timezone.h"
 
-#ifdef __AVR__
-    #include <avr/eeprom.h>
-#endif
+#if defined(__AVR__) || defined(ESP8266) || defined(ESP32)
+    #include <EEPROM.h>
+#endif  // defined(__AVR__) || defined(ESP8266) || defined(ESP32)
 
 /*----------------------------------------------------------------------*
  * Create a Timezone object from the given time change rules.           *
@@ -31,7 +31,7 @@ Timezone::Timezone(TimeChangeRule stdTime)
         initTimeChanges();
 }
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(ESP8266) || defined(ESP32)
 /*----------------------------------------------------------------------*
  * Create a Timezone object from time change rules stored in EEPROM     *
  * at the given address.                                                *
@@ -40,7 +40,7 @@ Timezone::Timezone(int address)
 {
     readRules(address);
 }
-#endif
+#endif  // defined(__AVR__) || defined(ESP8266) || defined(ESP32)
 
 /*----------------------------------------------------------------------*
  * Convert the given UTC time to local time, standard or                *
@@ -216,16 +216,16 @@ void Timezone::setRules(TimeChangeRule dstStart, TimeChangeRule stdStart)
     initTimeChanges();  // force calcTimeChanges() at next conversion call
 }
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined(ESP8266) || defined(ESP32)
 /*----------------------------------------------------------------------*
  * Read the daylight and standard time rules from EEPROM at             *
  * the given address.                                                   *
  *----------------------------------------------------------------------*/
 void Timezone::readRules(int address)
 {
-    eeprom_read_block((void *) &m_dst, (void *) address, sizeof(m_dst));
+    EEPROM.get(address, m_dst);
     address += sizeof(m_dst);
-    eeprom_read_block((void *) &m_std, (void *) address, sizeof(m_std));
+    EEPROM.get(address, m_std);
     initTimeChanges();  // force calcTimeChanges() at next conversion call
 }
 
@@ -235,9 +235,12 @@ void Timezone::readRules(int address)
  *----------------------------------------------------------------------*/
 void Timezone::writeRules(int address)
 {
-    eeprom_write_block((void *) &m_dst, (void *) address, sizeof(m_dst));
+    EEPROM.put(address, m_dst);
     address += sizeof(m_dst);
-    eeprom_write_block((void *) &m_std, (void *) address, sizeof(m_std));
+    EEPROM.put(address, m_std);
+#if defined(ESP8266) || defined(ESP32)
+    EEPROM.commit();
+#endif  // defined(ESP8266) || defined(ESP32)
 }
 
-#endif
+#endif  // defined(__AVR__) || defined(ESP8266) || defined(ESP32)


### PR DESCRIPTION
- Make `readRules` and `writeRules` functions compatible with ESP8266/ESP32
- Add esp8266 and esp32 to the library.properties `architectures` field

I updated the WriteRules example sketch to be compatible with ESP8266/ESP32. This meant adding some preprocessor directives which make it a bit less beginner friendly. I think it was worthwhile to demonstrate to the user that they need to call `EEPROM.begin()` in their own sketch if using the `readRules` or `writeRules` functions. If you prefer that sketch to remain in its previous AVR-only state, I'm happy to revert that part of this PR.

Fixes https://github.com/JChristensen/Timezone/issues/43

CC: @remcoNL