### PR TITLE
Allow inline declaration of TimeChangeRule. Saves 24 bytes RAM, does not affect current code.

### DIFF
--- a/src/Timezone.cpp
+++ b/src/Timezone.cpp
@@ -12,14 +12,6 @@
     #include <avr/eeprom.h>
 #endif
 
-
-TimeChangeRule::TimeChangeRule(const char *a, uint8_t w, uint8_t d,
-                               uint8_t m, uint8_t h, int o)
-    : week(w), dow(d), month(m), hour(h), offset(o)
-{
-    strncpy(abbrev, a, sizeof(abbrev));
-}
-
 /*----------------------------------------------------------------------*
  * Create a Timezone object from the given time change rules.           *
  *----------------------------------------------------------------------*/

--- a/src/Timezone.cpp
+++ b/src/Timezone.cpp
@@ -12,6 +12,13 @@
     #include <avr/eeprom.h>
 #endif
 
+TimeChangeRule::TimeChangeRule(const char *a, uint8_t w, uint8_t d,
+                               uint8_t m, uint8_t h, int o)
+    : week(w), dow(d), month(m), hour(h), offset(o)
+{
+    strncpy(abbrev, a, sizeof(abbrev));
+}
+
 /*----------------------------------------------------------------------*
  * Create a Timezone object from the given time change rules.           *
  *----------------------------------------------------------------------*/

--- a/src/Timezone.cpp
+++ b/src/Timezone.cpp
@@ -12,6 +12,14 @@
     #include <avr/eeprom.h>
 #endif
 
+
+TimeChangeRule::TimeChangeRule(const char *a, uint8_t w, uint8_t d,
+                               uint8_t m, uint8_t h, int o)
+    : week(w), dow(d), month(m), hour(h), offset(o)
+{
+    strncpy(abbrev, a, sizeof(abbrev));
+}
+
 /*----------------------------------------------------------------------*
  * Create a Timezone object from the given time change rules.           *
  *----------------------------------------------------------------------*/

--- a/src/Timezone.h
+++ b/src/Timezone.h
@@ -30,6 +30,10 @@ struct TimeChangeRule
     uint8_t month;     // 1=Jan, 2=Feb, ... 12=Dec
     uint8_t hour;      // 0-23
     int offset;        // offset from UTC in minutes
+
+    TimeChangeRule() = default;
+    TimeChangeRule(const char *abbrev, uint8_t week, uint8_t dow, 
+                   uint8_t month, uint8_t hour, int offset);
 };
         
 class Timezone

--- a/src/Timezone.h
+++ b/src/Timezone.h
@@ -30,8 +30,13 @@ struct TimeChangeRule
     uint8_t month;     // 1=Jan, 2=Feb, ... 12=Dec
     uint8_t hour;      // 0-23
     int offset;        // offset from UTC in minutes
+
+    TimeChangeRule() = default;
+    TimeChangeRule(const char *, uint8_t week, uint8_t dow, uint8_t month, uint8_t hour, int offset);
 };
         
+
+
 class Timezone
 {
     public:

--- a/src/Timezone.h
+++ b/src/Timezone.h
@@ -30,13 +30,8 @@ struct TimeChangeRule
     uint8_t month;     // 1=Jan, 2=Feb, ... 12=Dec
     uint8_t hour;      // 0-23
     int offset;        // offset from UTC in minutes
-
-    TimeChangeRule() = default;
-    TimeChangeRule(const char *, uint8_t week, uint8_t dow, uint8_t month, uint8_t hour, int offset);
 };
         
-
-
 class Timezone
 {
     public:


### PR DESCRIPTION
Allow inline declaration of TimeChangeRule.  Saves 24 bytes RAM, does not affect current code.
Instead of this:
TimeChangeRule PDT = {"PDT", Second, Sun, Mar, 2, -7 * 60};
TimeChangeRule PST = {"PST", First, Sun, Nov, 2, -8 * 60};


Timezone tz(PDT, PST);

you can now also:
Timezone tz(TimeChangeRule("PDT", Second, Sun, Mar, 2, -7 * 60),
    TimeChangeRule("PST", First, Sun, Nov, 2, -8 * 60));