### PR TITLE
Add support for ESP-Platform and its flash storage

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library to facilitate time zone conversions and automatic dayli
 paragraph=The primary aim of the Timezone library is to convert Universal Coordinated Time (UTC) to the correct local time, whether it is daylight saving time (a.k.a. summer time) or standard time.
 category=Timing
 url=https://github.com/JChristensen/Timezone
-architectures=avr
+architectures=avr,esp32
 depends=Time

--- a/src/Timezone.h
+++ b/src/Timezone.h
@@ -38,6 +38,7 @@ class Timezone
         Timezone(TimeChangeRule dstStart, TimeChangeRule stdStart);
         Timezone(TimeChangeRule stdTime);
         Timezone(int address);
+        Timezone(char* key);
         time_t toLocal(time_t utc);
         time_t toLocal(time_t utc, TimeChangeRule **tcr);
         time_t toUTC(time_t local);
@@ -45,7 +46,9 @@ class Timezone
         bool locIsDST(time_t local);
         void setRules(TimeChangeRule dstStart, TimeChangeRule stdStart);
         void readRules(int address);
+        void readRules(char* key);
         void writeRules(int address);
+        void writeRules(char* key);
 
     private:
         void calcTimeChanges(int yr);


### PR DESCRIPTION
Add support for the ESP-Platform using the preferences library. 
Tested on a LilyGo TTGo ESP32 T-Display.

resolves #65 